### PR TITLE
[fix] generate iterString error in bit operation

### DIFF
--- a/mixin_api.py
+++ b/mixin_api.py
@@ -114,16 +114,15 @@ class MIXIN_API:
 
         tsstring = tszero + tsone + tstwo + tsthree + '\0\0\0\0'
         if iterString is None:
-            ts = int(time.time() * 100000)
-            tszero = ts %   0x100
-            tsone = (ts %   0x10000) >> 8
-            tstwo = (ts %   0x1000000) >> 16
+            ts = int(time.time() * 1000000)
+            tszero = ts % 0x100
+            tsone = (ts % 0x10000) >> 8
+            tstwo = (ts % 0x1000000) >> 16
             tsthree = (ts % 0x100000000) >> 24
-            tsfour= (ts %    0x10000000000) >> 32
-            tsfive= (ts %   0x10000000000) >> 40
-            tssix = (ts %   0x1000000000000) >> 48
-            tsseven= (ts %  0x1000000000000) >> 56
-
+            tsfour = (ts % 0x10000000000) >> 32
+            tsfive = (ts % 0x1000000000000) >> 40
+            tssix = (ts % 0x100000000000000) >> 48
+            tsseven = (ts % 0x10000000000000000) >> 56
 
             tszero = chr(tszero).encode('latin1').decode('latin1')
             tsone = chr(tsone)


### PR DESCRIPTION
位运算从tsfive开始0的位数不正确
在一定情况下，会出现新的iterString比旧的小的情况，进而造成PIN incorrect